### PR TITLE
chore: updating to correct region tag prefix for product

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,28 +18,59 @@ The Maven artifact coordinates (`com.google.cloud:google-cloud-bigqueryreservati
 
 ## Quickstart
 
+If you are using Maven with [BOM][libraries-bom], add this to your pom.xml file:
 
-If you are using Maven, add this to your pom.xml file:
+```xml
+<dependencyManagement>
+  <dependencies>
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>libraries-bom</artifactId>
+      <version>26.1.4</version>
+      <type>pom</type>
+      <scope>import</scope>
+    </dependency>
+  </dependencies>
+</dependencyManagement>
+
+<dependencies>
+  <dependency>
+    <groupId>com.google.cloud</groupId>
+    <artifactId>google-cloud-bigqueryreservation</artifactId>
+    <version>2.4.6</version>
+  </dependency>
+
+```
+
+If you are using Maven without BOM, add this to your dependencies:
 
 
 ```xml
 <dependency>
   <groupId>com.google.cloud</groupId>
   <artifactId>google-cloud-bigqueryreservation</artifactId>
-  <version>2.6.0</version>
+  <version>2.4.6</version>
 </dependency>
+
 ```
 
+If you are using Gradle 5.x or later, add this to your dependencies:
+
+```Groovy
+implementation platform('com.google.cloud:libraries-bom:26.1.5')
+
+implementation 'com.google.cloud:google-cloud-bigqueryreservation'
+```
 If you are using Gradle without BOM, add this to your dependencies:
 
 ```Groovy
-implementation 'com.google.cloud:google-cloud-bigqueryreservation:2.6.0'
+implementation 'com.google.cloud:google-cloud-bigqueryreservation:2.7.0'
 ```
 
 If you are using SBT, add this to your dependencies:
 
 ```Scala
-libraryDependencies += "com.google.cloud" % "google-cloud-bigqueryreservation" % "2.6.0"
+libraryDependencies += "com.google.cloud" % "google-cloud-bigqueryreservation" % "2.7.0"
 ```
 
 ## Authentication

--- a/samples/install-without-bom/pom.xml
+++ b/samples/install-without-bom/pom.xml
@@ -25,13 +25,13 @@
 
 
   <dependencies>
-    <!-- [START bigqueryreservations_install_without_bom] -->
+    <!-- [START bigqueryreservation_install_without_bom] -->
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-bigqueryreservation</artifactId>
       <version>2.4.6</version>
     </dependency>
-    <!-- [END bigqueryreservations_install_without_bom] -->
+    <!-- [END bigqueryreservation_install_without_bom] -->
 
     <dependency>
       <groupId>junit</groupId>

--- a/samples/snippets/pom.xml
+++ b/samples/snippets/pom.xml
@@ -24,7 +24,7 @@
   </properties>
 
 
-  <!-- [START bigqueryreservations_install_with_bom] -->
+  <!-- [START bigqueryreservation_install_with_bom] -->
   <dependencyManagement>
     <dependencies>
       <dependency>
@@ -43,7 +43,7 @@
       <artifactId>google-cloud-bigqueryreservation</artifactId>
       <version>2.4.6</version>
     </dependency>
-    <!-- [END bigqueryreservations_install_with_bom] -->
+    <!-- [END bigqueryreservation_install_with_bom] -->
 
     <dependency>
       <groupId>junit</groupId>


### PR DESCRIPTION
Currently these samples are not associated with the correct product because the prefix is wrong. They are not used in documentation anywhere so should be safe to merge once tests pass. 
